### PR TITLE
fix: add type module to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "lib/Control.js",
   "author": "chris-m92",
   "license": "MIT",
+  "type": "module",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/chris-m92/react-leaflet-custom-control.git"


### PR DESCRIPTION
This change will fix the error "Cannot use import statement outside a module" when importing the module.